### PR TITLE
Add neon landing page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,3 +120,12 @@
     @apply bg-background text-foreground;
   }
 }
+
+.neon {
+  color: #00ffc2;
+  text-shadow:
+    0 0 5px #00ffc2,
+    0 0 10px #00ffc2,
+    0 0 20px #00ffc2,
+    0 0 40px #00ffc2;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,10 @@
-export default function Home() {
+export default function Home(): JSX.Element {
   return (
-    <section className="flex flex-col items-center justify-center p-4 text-center gap-4">
-      <h1 className="text-4xl font-bold">Welcome to My Portfolio</h1>
-      <p className="text-lg">Showcasing projects and experience.</p>
+    <section className="flex flex-col items-center justify-center text-center gap-6 py-24 bg-gradient-to-br from-black via-fuchsia-800/30 to-black">
+      <h1 className="neon text-5xl font-bold sm:text-6xl">Welcome to My Portfolio</h1>
+      <p className="neon text-xl max-w-2xl">
+        Experienced developer crafting responsive and high-performance web applications.
+      </p>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- implement neon styling for the landing page
- add `.neon` helper class for glowing text

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683feab822388321ac49c4aa7a55ec0e